### PR TITLE
Right order for bool values

### DIFF
--- a/Enum.php
+++ b/Enum.php
@@ -449,8 +449,8 @@ class Enum extends \yii\helpers\Inflector
     public static function boolList($true = 'Yes', $false = 'No')
     {
         return [
-            true => $true,
-            false => $false
+            false => $false,    // == 0
+            true => $true,      // == 1
         ];
     }
 


### PR DESCRIPTION
Is treated as false and true 0 to 1, it would be coherent to create a
table with a ordered index.