### PR TITLE
fixed "a moment ago" readout

### DIFF
--- a/Enum.php
+++ b/Enum.php
@@ -177,7 +177,7 @@ class Enum extends Inflector
         }
         if ($human) {
             if ($interval <= 0) {
-                $elapsed = Yii::t('kvenum', 'a moment ago');
+                $elapsed = Yii::t('kvenum', 'a moment');
             } elseif ($interval < 60) {
                 $elapsed = Yii::t('kvenum', '{n, plural, one{one second} other{# seconds}}', [ 'n' => $interval]);
             } elseif ($interval >= 60 && $interval < $intervals['hour']) {


### PR DESCRIPTION
“ago” was doubling up

## Scope
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-helpers/blob/master/CHANGE.md)):

- fixed "a moment ago ago" doubling up issue.

## Related Issues
If this is related to an existing ticket, include a link to it as well.