### PR TITLE
PHP 8.3 compatible modulus operations (convertTri)

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -296,8 +296,8 @@ class Enum extends Inflector
     {
         // chunk the number ...xyz
         $x = (int)($num / 1000);
-        $y = ($num / 100) % 10;
-        $z = $num % 100;
+        $y = (int)($num / 100) % 10;
+        $z = (int)$num % 100;
 
         // init the output string
         $str = "";


### PR DESCRIPTION
php8.3 is throwing this warning:
Implicit conversion from float 7 to int loses precision

## Scope
This pull request includes a

- [X ] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-helpers/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.